### PR TITLE
Prevent staff users from accessing site while courses are being setup

### DIFF
--- a/app/client/app/models/user.ts
+++ b/app/client/app/models/user.ts
@@ -12,4 +12,5 @@ export class User {
     authLevel: string;
     error: string;
     success: string;
+    notify: boolean;
 }

--- a/app/server/src/controllers/StaffController.ts
+++ b/app/server/src/controllers/StaffController.ts
@@ -69,7 +69,7 @@ class StaffController {
                                                       // setup email data with unicode symbols
                                                       let mailOptions = {
                                                         from: mail.user, // sender address
-                                                        to: staff.email, // list of receivers
+                                                        to: 'BA.ACP@georgiancollege.ca', // use staff.email
                                                         subject: 'Welcome!', // Subject line
                                                         text: '', // plain text body
                                                         html: 'Your username is <b>' + staff.username + '</b> and here is your new temporary password: <b>' + randomstring + '</b><br /> Please login at ' + site_settings.url + '  <br /><br /> Thankyou'// html body

--- a/app/server/src/services/MailService.ts
+++ b/app/server/src/services/MailService.ts
@@ -1,7 +1,6 @@
 const nodemailer = require('nodemailer');
 var config = require('../config');
 
-
 // create reusable transporter object using the default SMTP transport
 let transporter = nodemailer.createTransport({
   service: config.mail.service,

--- a/app/server/src/services/ScheduleService.ts
+++ b/app/server/src/services/ScheduleService.ts
@@ -73,7 +73,7 @@ var attendanceCheck = schedule.scheduleJob('0 30 19 * * *', function() {
                                   console.log("__________________________________________________________________________________________");
                                   fourMissedClasses += 1;
                                   let mailOptions = {
-                                    from: 'Academic/Career Preparation <academic.career.prep@gmail.com>', // sender address
+                                    from: config.mail.user, // sender address
                                     to: userInfo[0].email, // list of receivers
                                     subject: 'Removal from ' + courseInfo[0].courseName, // Subject line
                                     text: '', // plain text body
@@ -113,7 +113,7 @@ var attendanceCheck = schedule.scheduleJob('0 30 19 * * *', function() {
                                   console.log("__________________________________________________________________________________________");
                                   twoMissedClasses += 1;
                                   let mailOptions = {
-                                    from: 'Academic/Career Preparation <academic.career.prep@gmail.com>', // sender address
+                                    from: config.mail.user, // sender address
                                     to: userInfo[0].email, // student.email
                                     subject: 'Two Missed ' + courseInfo[0].courseName + ' Classes', // Subject line
                                     text: '', // plain text body


### PR DESCRIPTION
@ThomasLamb Jim has requested that emails being sent when a new staff user is created be disabled for now while courses are being setup. This pull request changes the recipient from the newly created staff users email address to 'BA.ACP@georgiancollege.ca'.